### PR TITLE
fix: comment out link for adding requests in RequestsListPage

### DIFF
--- a/src/app/dashboard/requests/page.tsx
+++ b/src/app/dashboard/requests/page.tsx
@@ -415,11 +415,11 @@ export default function RequestsListPage() {
                                 <Button variant="ghost" size="md" icon={RefreshCw} onClick={handleRefresh}>
                                     Yenile
                                 </Button>
-                                <Link href="/dashboard/requests/add">
+                                {/* <Link href="/dashboard/requests/add">
                                     <Button variant="primary" size="md" icon={Plus}>
                                         Yeni Talep
                                     </Button>
-                                </Link>
+                                </Link> */}
                             </div>
                         </div>
 

--- a/src/app/dashboard/requests/resolved/page.tsx
+++ b/src/app/dashboard/requests/resolved/page.tsx
@@ -394,11 +394,11 @@ export default function ResolvedRequestsPage() {
                                 <Button variant="ghost" size="md" icon={RefreshCw} onClick={handleRefresh}>
                                     Yenile
                                 </Button>
-                                <Link href="/dashboard/requests/add">
+                                {/* <Link href="/dashboard/requests/add">
                                     <Button variant="primary" size="md" icon={Plus}>
                                         Yeni Talep
                                     </Button>
-                                </Link>
+                                </Link> */}
                             </div>
                         </div>
 

--- a/src/app/dashboard/requests/waiting/page.tsx
+++ b/src/app/dashboard/requests/waiting/page.tsx
@@ -396,11 +396,11 @@ export default function WaitingRequestsPage() {
                                 <Button variant="ghost" size="md" icon={RefreshCw} onClick={handleRefresh}>
                                     Yenile
                                 </Button>
-                                <Link href="/dashboard/requests/add">
+                                {/* <Link href="/dashboard/requests/add">
                                     <Button variant="primary" size="md" icon={Plus}>
                                         Yeni Talep
                                     </Button>
-                                </Link>
+                                </Link> */}
                             </div>
                         </div>
 


### PR DESCRIPTION
- Commented out the Link component for the "Yeni Talep" button in RequestsListPage to prevent navigation while maintaining the button's structure for future use.
- This change is intended to streamline the user interface during ongoing development.