### PR TITLE
fix: comment out unused resident addition button and sidebar menu item

### DIFF
--- a/src/app/components/ui/Sidebar.tsx
+++ b/src/app/components/ui/Sidebar.tsx
@@ -68,7 +68,7 @@ const menuItems: MenuItemProps[] = [
         icon: Users,
         children: [
             { title: 'Sakin Listesi', icon: User, href: '/dashboard/residents' },
-            { title: 'Yeni Sakin Ekle', icon: UserPlus, href: '/dashboard/residents/add' },
+            // { title: 'Yeni Sakin Ekle', icon: UserPlus, href: '/dashboard/residents/add' },
             { title: 'Onay Bekleyenler', icon: UserCheck, href: '/dashboard/residents/pending' }
         ]
     },

--- a/src/app/dashboard/residents/page.tsx
+++ b/src/app/dashboard/residents/page.tsx
@@ -680,9 +680,9 @@ export default function ResidentsPage() {
                                     variant="secondary"
                                     size="md"
                                 />
-                                <Button variant="primary" size="md" icon={Plus} onClick={handleAddNewResident}>
+                                {/* <Button variant="primary" size="md" icon={Plus} onClick={handleAddNewResident}>
                                     Yeni Sakin
-                                </Button>
+                                </Button> */}
                             </div>
                         </div>
 


### PR DESCRIPTION
- Commented out the "Yeni Sakin Ekle" button in the ResidentsPage to prevent functionality during ongoing development.
- Also commented out the corresponding menu item in the Sidebar for consistency and to maintain a clean codebase.